### PR TITLE
Fix spacing offset issue for Parser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/add/AddCommandParserWrapper.java
+++ b/src/main/java/seedu/address/logic/parser/add/AddCommandParserWrapper.java
@@ -33,7 +33,7 @@ public class AddCommandParserWrapper implements Parser<AddCommandAbstract> {
 
         // comment out these 2 lines to access og addresss book
         checkArgumentTypeSufficiency(argumentTypes);
-        String itemPrefixes = argumentTypes[ITEM_PREFIX_INDEX];
+        String itemPrefixes = " " + argumentTypes[ITEM_PREFIX_INDEX];
         switch (itemType) {
         case ITEM_PREFIX_COMPANY:
             return null;


### PR DESCRIPTION
Tiny offset issue: argMultimap require an extra space to parse the parameter.